### PR TITLE
3.5.18

### DIFF
--- a/commands/Admin/Exp/expadd.js
+++ b/commands/Admin/Exp/expadd.js
@@ -1,0 +1,60 @@
+const {
+    Command
+} = require("discord-akairo");
+const {
+    inspect
+} = require("util");
+const {
+    successMessage,
+    errorMessage,
+    warnMessage,
+    promptMessage
+} = require('../../../utils/messages');
+const Discord = require("discord.js");
+const moment = require("moment");
+const textes = new (require(`../../../utils/textes.js`));
+
+class expAddCommand extends Command {
+    constructor() {
+        super("exp-add", {
+            aliases: ["expadd"],
+            category: "Admin",
+            description: {
+                content: textes.get('EXP_CMD_ADD_DESCRIPTION_CONTENT'),
+                usage: textes.get('EXP_CMD_ADD_DESCRIPTION_USAGE'),
+            },
+        });
+    }
+
+    * args(message) {
+        const userdata = yield {
+            type: 'userdata',
+            prompt: {
+                start: message => promptMessage(textes.get('CMD_USERDATA_PROMPT')),
+                retry: message => promptMessage(textes.get('CMD_USERDATA_RETRY'))
+            }
+        };
+        const xpamount = yield {
+            type: 'number',
+            prompt: {
+                start: message => promptMessage(textes.get('EXP_CMD_ADD_XPAMOUNT_PROMPT')),
+                retry: message => promptMessage(textes.get('EXP_CMD_ADD_XPAMOUNT_RETRY'))
+            }
+        };
+
+        return { userdata, xpamount };
+    }
+
+    async exec(message, args) {
+        let client = this.client;
+
+        args.userdata.xp += args.xpamount;
+        args.userdata.level = client.xpGetLevel(args.userdata.xp);
+        client.userdataSet(args.userdata);
+
+        successMessage(textes.get("EXP_CMD_ADD_SUCCESS", args.userdata, args.xpamount), message.channel);
+    }
+
+}
+
+module.exports = expAddCommand;

--- a/commands/Admin/Exp/explvlset.js
+++ b/commands/Admin/Exp/explvlset.js
@@ -1,0 +1,60 @@
+const {
+    Command
+} = require("discord-akairo");
+const {
+    inspect
+} = require("util");
+const {
+    successMessage,
+    errorMessage,
+    warnMessage,
+    promptMessage
+} = require('../../../utils/messages');
+const Discord = require("discord.js");
+const moment = require("moment");
+const textes = new (require(`../../../utils/textes.js`));
+
+class expLvlSetCommand extends Command {
+    constructor() {
+        super("exp-lvlset", {
+            aliases: ["explvlset"],
+            category: "Admin",
+            description: {
+                content: textes.get('EXP_CMD_LVLSET_DESCRIPTION_CONTENT'),
+                usage: textes.get('EXP_CMD_LVLSET_DESCRIPTION_USAGE'),
+            },
+        });
+    }
+
+    * args(message) {
+        const userdata = yield {
+            type: 'userdata',
+            prompt: {
+                start: message => promptMessage(textes.get('CMD_USERDATA_PROMPT')),
+                retry: message => promptMessage(textes.get('CMD_USERDATA_RETRY'))
+            }
+        };
+        const level = yield {
+            type: 'number',
+            prompt: {
+                start: message => promptMessage(textes.get('EXP_CMD_LVLSET_LEVEL_PROMPT')),
+                retry: message => promptMessage(textes.get('EXP_CMD_LVLSET_LEVEL_RETRY'))
+            }
+        };
+
+        return { userdata, level };
+    }
+
+    async exec(message, args) {
+        let client = this.client;
+
+        args.userdata.level = args.level;
+        args.userdata.xp = client.levelGetXP(args.level);
+        client.userdataSet(args.userdata);
+
+        successMessage(textes.get("EXP_CMD_LVLSET_SUCCESS", args.userdata), message.channel);
+    }
+
+}
+
+module.exports = expLvlSetCommand;

--- a/commands/Admin/Exp/expreinit.js
+++ b/commands/Admin/Exp/expreinit.js
@@ -1,0 +1,49 @@
+const {
+    Command
+} = require("discord-akairo");
+const {
+    inspect
+} = require("util");
+const {
+    successMessage,
+    errorMessage,
+    warnMessage,
+    promptMessage
+} = require('../../../utils/messages');
+const Discord = require("discord.js");
+const moment = require("moment");
+const textes = new (require(`../../../utils/textes.js`));
+
+class expReinitCommand extends Command {
+    constructor() {
+        super("exp-reinit", {
+            aliases: ["expinit","expri"],
+            category: "Admin",
+            description: {
+                content: textes.get('EXP_CMD_REINIT_DESCRIPTION_CONTENT'),
+                usage: textes.get('EXP_CMD_REINIT_DESCRIPTION_USAGE'),
+            },
+        });
+    }
+
+    * args(message) {
+
+    }
+
+    async exec(message, args) {
+        let client = this.client;
+        let userdatas = client.userdataGetAll(true);
+
+        for (const userdata of userdatas) {
+            userdata.xp = 0;
+            userdata.level = 1;
+            client.userdataSet(userdata);
+            client.log(`Expérience réinitialisée pour ${userdata.displayName}`);
+        }
+
+        successMessage(textes.get("EXP_CMD_REINIT_SUCCESS", userdatas.length), message.channel);
+    }
+
+}
+
+module.exports = expReinitCommand;

--- a/commands/Admin/Exp/expset.js
+++ b/commands/Admin/Exp/expset.js
@@ -1,0 +1,60 @@
+const {
+    Command
+} = require("discord-akairo");
+const {
+    inspect
+} = require("util");
+const {
+    successMessage,
+    errorMessage,
+    warnMessage,
+    promptMessage
+} = require('../../../utils/messages');
+const Discord = require("discord.js");
+const moment = require("moment");
+const textes = new (require(`../../../utils/textes.js`));
+
+class expSetCommand extends Command {
+    constructor() {
+        super("exp-set", {
+            aliases: ["expset"],
+            category: "Admin",
+            description: {
+                content: textes.get('EXP_CMD_SET_DESCRIPTION_CONTENT'),
+                usage: textes.get('EXP_CMD_SET_DESCRIPTION_USAGE'),
+            },
+        });
+    }
+
+    * args(message) {
+        const userdata = yield {
+            type: 'userdata',
+            prompt: {
+                start: message => promptMessage(textes.get('CMD_USERDATA_PROMPT')),
+                retry: message => promptMessage(textes.get('CMD_USERDATA_RETRY'))
+            }
+        };
+        const xptotal = yield {
+            type: 'number',
+            prompt: {
+                start: message => promptMessage(textes.get('EXP_CMD_SET_XPTOTAL_PROMPT')),
+                retry: message => promptMessage(textes.get('EXP_CMD_SET_XPTOTAL_RETRY'))
+            }
+        };
+
+        return { userdata, xptotal };
+    }
+
+    async exec(message, args) {
+        let client = this.client;
+
+        args.userdata.xp = args.xptotal;
+        args.userdata.level = client.xpGetLevel(args.userdata.xp);
+        client.userdataSet(args.userdata);
+
+        successMessage(textes.get("EXP_CMD_SET_SUCCESS", args.userdata), message.channel);
+    }
+
+}
+
+module.exports = expSetCommand;

--- a/commands/Admin/exp.js
+++ b/commands/Admin/exp.js
@@ -118,12 +118,8 @@ class expCommand extends Command {
                     );
                     if (memberMessages) {
                         for (const message of memberMessages) {
-                            if (!message.content.startsWith("https://tenor.com") && !message.content.startsWith("https://media.tenor.com")) {
-                                if (message.content.length > 150) {
-                                    userdata.xp += 100;
-                                } else {
+                            if (!message.content.startsWith("https://tenor.com") && !message.content.startsWith("https://media.tenor.com") && !message.content.startsWith("!")) {
                                     userdata.xp += 25;
-                                }
                             }
                         }
                         userdata.level = client.xpGetLevel(userdata.xp);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "3.5.17",
+  "version": "3.5.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "3.5.17",
+  "version": "3.5.18",
   "description": "Bot du serveur discord Casual Effect",
   "main": "index.js",
   "dependencies": {

--- a/utils/textes.js
+++ b/utils/textes.js
@@ -515,6 +515,42 @@ module.exports = class {
 
                 return `${member.displayName} à rejoint Casual Effect !`;
             },
+
+            EXP_CMD_REINIT_DESCRIPTION_CONTENT: `Réinitialisation de l'expérience`,
+            EXP_CMD_REINIT_DESCRIPTION_USAGE: `La commande se lance sans paramètre: \`!expreinit\`
+            
+            Attention: Cette commande réinitialise l'expérience de tous les membres du discord.`,
+        
+            EXP_CMD_REINIT_SUCCESS: (number) => {
+                return `L'expérience à été remise à zéro pour ${number} membres`;
+            },
+            EXP_CMD_ADD_DESCRIPTION_CONTENT: `Ajouter de l'expérience à un membre`,
+            EXP_CMD_ADD_DESCRIPTION_USAGE: `La commande se lance sans paramètre: \`!expadd\`
+            Elle peut aussi se lancer en spécifiant les paramètres: \`!expadd <ID membre> <montant exp>\``,
+            EXP_CMD_ADD_XPAMOUNT_PROMPT: `Quel est le montant d'expérience à ajouter ?`,
+            EXP_CMD_ADD_XPAMOUNT_RETRY: `Veuillez spécifier un nombre. Quel est le montant d'expérience à ajouter ?`,
+            EXP_CMD_ADD_SUCCESS: (userdata, xpamount) => {
+                return `${xpamount} points d'expérience ont été ajoutés ${userdata.displayName}. Il a désormais ${userdata.xp} points d'expérience et il est level ${userdata.level}`;
+            },
+
+            EXP_CMD_SET_DESCRIPTION_CONTENT: `Attribue un montant d'expérience à un membre`,
+            EXP_CMD_SET_DESCRIPTION_USAGE: `La commande se lance sans paramètre: \`!expset\`
+            Elle peut aussi se lancer en spécifiant les paramètres: \`!expset <ID membre> <montant exp>\``,
+            EXP_CMD_SET_XPTOTAL_PROMPT: `Quel est le nouveau montant total d'expérience ?`,
+            EXP_CMD_SET_XPTOTAL_RETRY: `Veuillez spécifier un nombre. Quel est le montant total d'expérience ?`,
+            EXP_CMD_SET_SUCCESS: (userdata) => {
+                return `${userdata.displayName} a désormais ${userdata.xp} points d'expérience et il est level ${userdata.level}`;
+            },
+
+            EXP_CMD_LVLSET_DESCRIPTION_CONTENT: `Attribue un level à un membre`,
+            EXP_CMD_LVLSET_DESCRIPTION_USAGE: `La commande se lance sans paramètre: \`!explvlset\`
+            Elle peut aussi se lancer en spécifiant les paramètres: \`!explvlset <ID membre> <level>\``,
+            EXP_CMD_LVLSET_LEVEL_PROMPT: `Quel est le nouveau level pour ce membre ?`,
+            EXP_CMD_LVLSET_LEVEL_RETRY: `Veuillez spécifier un nombre. Quel est le nouveau level pour ce membre ?`,
+            EXP_CMD_LVLSET_SUCCESS: (userdata) => {
+                return `${userdata.displayName} est désormais ${userdata.level} avec ${userdata.xp} points d'expérience`;
+            },
+
             EXP_LOG_ADDXP: (member, xp, reason) => {
                 return `${member.displayName} à gagné ${xp}xp (${reason})`;
             },


### PR DESCRIPTION
- Ajout commande expadd: Ajouter de l'expérience à un membre
- Ajout commande expset: Définir le montant d'expérience total d'un membre
- Ajout commande explvlset: Définir le level d'un membre
- Ajout commande expreinit: Réinitialiser l'expérience de tous les membres (commande dangereuse !)
- Simulation de l'initialisation de l'expérience: Ne tiens pas compte des commandes. 25 pts pour tous les messages même ceux de plus de 150 caractères